### PR TITLE
fix: address next/image warnings in event components

### DIFF
--- a/app/components/events/EventDetail.tsx
+++ b/app/components/events/EventDetail.tsx
@@ -3,6 +3,7 @@
 import { useIntl } from '../Intl'
 import { Event } from '@/types/events'
 import Link from 'next/link'
+import Image from 'next/image'
 import { Disclosure } from '@headlessui/react'
 import { CalendarIcon, MapPinIcon, ArrowLeftIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
 import { getSponsorsByEvent } from '@/data/sponsors'
@@ -116,10 +117,13 @@ export default function EventDetail({ event, locale }: { event: Event; locale: s
 
             {event.imageUrl && (
               <div className="lg:sticky lg:top-8">
-                <img
+                <Image
                   src={event.imageUrl}
                   alt={event.name}
-                  className="w-full rounded-xl shadow-sm"
+                  width={1200}
+                  height={630}
+                  priority
+                  className="w-full h-auto rounded-xl shadow-sm"
                 />
               </div>
             )}
@@ -170,6 +174,7 @@ export default function EventDetail({ event, locale }: { event: Event; locale: s
                   rel="noopener noreferrer"
                   className="hover:opacity-80 transition-opacity"
                 >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img src={sponsor.logo} alt={sponsor.name} className="h-10 w-auto max-w-[140px] object-contain" />
                 </a>
               ))}
@@ -185,6 +190,7 @@ export default function EventDetail({ event, locale }: { event: Event; locale: s
                       rel="noopener noreferrer"
                       className="hover:opacity-80 transition-opacity"
                     >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img src={cs.logo} alt={cs.name} className="h-8 w-auto max-w-[100px] object-contain" />
                     </a>
                   ))}
@@ -200,6 +206,7 @@ export default function EventDetail({ event, locale }: { event: Event; locale: s
               {judges.map((judge) => (
                 <div key={judge.name} className="text-center">
                   {judge.image?.src && (
+                    /* eslint-disable-next-line @next/next/no-img-element */
                     <img src={judge.image.src} alt={judge.name} className="w-16 h-16 rounded-full mx-auto mb-2 object-cover" />
                   )}
                   <p className="text-sm font-medium text-slate-900">{judge.name}</p>
@@ -216,6 +223,7 @@ export default function EventDetail({ event, locale }: { event: Event; locale: s
               {mentors.map((mentor) => (
                 <div key={mentor.name} className="text-center">
                   {mentor.image?.src && (
+                    /* eslint-disable-next-line @next/next/no-img-element */
                     <img src={mentor.image.src} alt={mentor.name} className="w-16 h-16 rounded-full mx-auto mb-2 object-cover" />
                   )}
                   <p className="text-sm font-medium text-slate-900">{mentor.name}</p>

--- a/app/components/events/EventList.tsx
+++ b/app/components/events/EventList.tsx
@@ -4,6 +4,7 @@ import { useIntl } from '../Intl'
 import { getUpcomingEvents, getPastEvents } from '@/lib/events'
 import { getUpcomingHackNights, getPastHackNights } from '@/data/hacknights'
 import Link from 'next/link'
+import Image from 'next/image'
 import { CalendarIcon, MapPinIcon } from '@heroicons/react/24/outline'
 
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
@@ -108,9 +109,11 @@ export default function EventList() {
                     className="flex items-center gap-5 p-4 rounded-xl border border-gray-100 hover:border-gray-200 hover:shadow-sm transition-all"
                   >
                     {event.imageUrl && (
-                      <img
+                      <Image
                         src={event.imageUrl}
                         alt={event.name}
+                        width={80}
+                        height={80}
                         className="w-20 h-20 rounded-lg object-cover flex-shrink-0"
                       />
                     )}

--- a/app/components/events/HackNightDetail.tsx
+++ b/app/components/events/HackNightDetail.tsx
@@ -3,6 +3,7 @@
 import { useIntl } from '../Intl'
 import { HackNight } from '@/data/hacknights'
 import Link from 'next/link'
+import Image from 'next/image'
 import { CalendarIcon, MapPinIcon, ArrowLeftIcon, UsersIcon } from '@heroicons/react/24/outline'
 
 const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
@@ -100,10 +101,13 @@ export default function HackNightDetail({ hackNight }: { hackNight: HackNight })
 
           {hackNight.imageUrl && (
             <div className="lg:sticky lg:top-8">
-              <img
+              <Image
                 src={hackNight.imageUrl}
                 alt={hackNight.name}
-                className="w-full rounded-xl shadow-sm"
+                width={1200}
+                height={630}
+                priority
+                className="w-full h-auto rounded-xl shadow-sm"
               />
             </div>
           )}
@@ -114,6 +118,7 @@ export default function HackNightDetail({ hackNight }: { hackNight: HackNight })
             <h2 className="text-2xl font-semibold text-slate-900 mb-6">{intl.t('events.gallery')}</h2>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
               {hackNight.gallery.map((img, i) => (
+                /* eslint-disable-next-line @next/next/no-img-element */
                 <img
                   key={i}
                   src={img}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,14 @@ const nextConfig = {
   // Optionally, add any other Next.js config below
   // output: "export", // Will export all routes as static html
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.lumacdn.com',
+      },
+    ],
+  },
   redirects: async () => {
     return [
       {


### PR DESCRIPTION
## Summary
- Migrate hero and thumbnail `<img>` tags in `EventDetail.tsx`, `EventList.tsx`, and `HackNightDetail.tsx` to `next/image` with explicit dimensions and `priority` on above-the-fold images.
- Keep variable-aspect sponsor/community logos and judge/mentor avatars (which can be expiring LinkedIn signed URLs) as `<img>` with per-line `eslint-disable-next-line @next/next/no-img-element`. Adding LinkedIn to `remotePatterns` would defeat caching since signed URLs expire.
- Add `images.lumacdn.com` to `next.config.mjs` `remotePatterns` so hacknight cover images served from Luma work under `next/image`.
- Resolves all 8 `@next/next/no-img-element` warnings in the events components introduced by PR #4.

## Test plan
- [x] `npm run lint` — 8 originally-flagged warnings cleared (other unrelated files still have warnings, out of scope).
- [x] `npx tsc --noEmit` — clean.
- [ ] Visit `/[locale]/events` and confirm hackathon + hacknight thumbnails render at 80×80.
- [ ] Visit `/[locale]/events/v1-2024` (and a hacknight slug) and confirm hero image renders without layout shift.
- [ ] Spot-check that judge and mentor LinkedIn-sourced avatars still load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)