### PR TITLE
Attribute the homepage hero RSVP link

### DIFF
--- a/app/components/home/OrgHero.tsx
+++ b/app/components/home/OrgHero.tsx
@@ -7,6 +7,8 @@ import type { Event } from '@/types/events'
 import SubscribeForm from './SubscribeForm'
 import Polaroid from '../Polaroid'
 import RecapLightbox from '../RecapLightbox'
+import { withUtm } from '../../helpers/utm'
+import { trackOutbound } from '../../helpers/track'
 
 type HeroPolaroid = {
   src: string
@@ -121,11 +123,25 @@ export default function OrgHero({
                 <p className="mt-1 text-sm text-ink-dim">{upcoming.location}</p>
 
                 <div className="mt-5 flex flex-wrap items-center gap-4">
+                  {/* The site's most prominent RSVP link, so it carries the
+                      same attribution as the two on the event page. withUtm
+                      passes internal hrefs through untouched, so the fallback
+                      to the event page stays clean. */}
                   <a
-                    href={upcoming.registrationUrl || eventHref}
+                    href={withUtm(upcoming.registrationUrl || eventHref, {
+                      medium: 'cta',
+                      campaign: `hackbarna-${upcoming.slug}`,
+                      content: 'register-home-hero',
+                    })}
                     {...(upcoming.registrationUrl
                       ? { target: '_blank', rel: 'noopener noreferrer' }
                       : {})}
+                    onClick={() =>
+                      trackOutbound('registration_click', {
+                        event_slug: upcoming.slug,
+                        source: 'register-home-hero',
+                      })
+                    }
                     className="hb-px inline-flex items-center gap-2 bg-accent px-5 py-2.5 text-sm font-semibold text-ground transition-colors hover:bg-inversion focus-visible:outline-none focus-visible:ring-inset focus-visible:ring-2 focus-visible:ring-ground"
                   >
                     {intl.t('events.register')}


### PR DESCRIPTION
`EventDetail` already ran both of its registration CTAs through `withUtm`, but the **homepage hero CTA** had neither UTM tags nor a `trackOutbound` call. It was added when the hero was rebuilt around the next event, so it is now the most prominent RSVP link on the site — and Luma has been seeing all of that traffic as direct.

## Change

One link, following the convention already documented in `app/helpers/utm.ts`:

| link | medium | campaign | content |
|---|---|---|---|
| event page, hero | `cta` | `hackbarna-<slug>` | `register-hero` |
| event page, bottom | `cta` | `hackbarna-<slug>` | `register-bottom` |
| **homepage hero** (new) | `cta` | `hackbarna-<slug>` | `register-home-hero` |

Distinct `utm_content` so the homepage and event-page CTAs separate in analytics. Also adds the matching `registration_click` `trackOutbound` call the other two already had.

`withUtm` passes non-http URLs through untouched, so the fallback to the internal event page — used when an edition has no `registrationUrl` — is unaffected.

## Verified

Built and served. The rendered anchor is now:

```
https://luma.com/3gswve8n?utm_source=hackbarna&utm_medium=cta
  &utm_campaign=hackbarna-aisummit26&utm_content=register-home-hero
```

Checked that every rendered `href` pointing at luma.com carries UTMs. The bare `luma.com` strings visible in the page source are `registrationUrl` props in the RSC payload, not links.

## Not included

- `SubscribeForm`'s Typeform link has no UTMs, though the legacy `ApplyButton` UTMs the same form. That is a newsletter signup rather than an RSVP, so it is outside this change — worth a follow-up if you want the inconsistency closed.
- `EventCard` has external-href handling but every current caller passes an internal route, so nothing there is un-attributed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)