### PR TITLE
Add a sponsorship CTA to the upcoming event page

### DIFF
--- a/app/components/events/EventDetail.tsx
+++ b/app/components/events/EventDetail.tsx
@@ -93,6 +93,7 @@ function SponsorBlock({
   isHackNight,
   hackNightSponsor,
   eventSlug,
+  eventName,
 }: {
   sponsors: Sponsor[]
   communitySponsors: Sponsor[]
@@ -100,6 +101,7 @@ function SponsorBlock({
   isHackNight: boolean
   hackNightSponsor?: string
   eventSlug: string
+  eventName: string
 }) {
   const campaign = `hackbarna-${eventSlug}`
   const deckCampaign = `hackbarna-${eventSlug}-deck`
@@ -256,6 +258,59 @@ function SponsorBlock({
                   />
                 </a>
               ))}
+            </div>
+          </div>
+        )}
+
+        {/* Someone reading the sponsor list is exactly who might want to join
+            it, so the pitch sits here rather than at the foot of the page.
+            accent-alt is deliberately the opposite channel to the Register
+            button in both registers — cyan when Register is pink, pink when
+            Register is cyan — so it reads as a second audience, not a
+            competing primary action. */}
+        {!isPast && (
+          <div className="hb-px hb-px-shadow mt-2 bg-accent-alt/40 p-px">
+            <div className="hb-px flex flex-col gap-5 bg-ground-raised p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+              <div>
+                <p className="text-lg font-semibold text-ink">
+                  Want your logo here?
+                </p>
+                <p className="mt-1.5 text-sm text-ink-dim max-w-md">
+                  We build every edition with companies that want to spend a
+                  weekend with the people they hire.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-4 sm:flex-shrink-0">
+                <a
+                  href="/sponsorship.pdf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    trackOutbound('sponsorship_deck_click', {
+                      event_slug: eventSlug,
+                      source: 'sponsor-block',
+                    })
+                  }
+                  className="hb-px inline-flex items-center gap-2 bg-accent-alt px-5 py-2.5 text-sm font-semibold text-ground transition-opacity hover:opacity-85 focus-visible:outline-none focus-visible:ring-inset focus-visible:ring-2 focus-visible:ring-ground"
+                >
+                  Sponsorship deck
+                  <span aria-hidden="true">→</span>
+                </a>
+                <a
+                  href={`mailto:team@hackbarna.com?subject=${encodeURIComponent(
+                    `Sponsoring ${eventName}`
+                  )}`}
+                  onClick={() =>
+                    trackOutbound('sponsor_contact_click', {
+                      event_slug: eventSlug,
+                      source: 'sponsor-block',
+                    })
+                  }
+                  className="text-sm font-semibold text-ink-dim underline underline-offset-4 transition-colors hover:text-ink"
+                >
+                  Talk to us
+                </a>
+              </div>
             </div>
           </div>
         )}
@@ -469,6 +524,7 @@ export default function EventDetail({
           isHackNight={isHackNight}
           hackNightSponsor={event.sponsor}
           eventSlug={event.slug}
+          eventName={event.name}
         />
 
         {/* Partners with roles (hack nights) */}

--- a/app/helpers/track.ts
+++ b/app/helpers/track.ts
@@ -13,6 +13,7 @@ type OutboundEvent =
   | 'sponsor_click'
   | 'community_sponsor_click'
   | 'sponsorship_deck_click'
+  | 'sponsor_contact_click'
   | 'registration_click'
   | 'partner_marquee_click'
 


### PR DESCRIPTION
The sponsor block already had a pitch, but it only rendered when a future event had **no sponsors at all**. aisummit26 has eight, so anyone reading that list had no way to reach out.

## Where it goes, and why

Directly after the sponsor logos, not at the foot of the page. Someone scrolling the sponsor list is exactly the person who might want to be on it.

It uses `accent-alt`, which is the **opposite channel to Register in both registers** — cyan when Register is pink, pink when Register is cyan. The sponsorship pitch targets a second audience, so it should read as distinct rather than compete with the page's primary action. Contrast holds either way: near-black is 6.14:1 on pink and 12.95:1 on cyan.

Offers two paths: the deck, and a mailto with an event-specific subject (`Sponsoring HackBarna AI Summit 26`).

## Scoping

Gated on the existing `isPast` flag rather than the `aisummit26` slug — a finished event can't be sponsored, and hack nights already return early from this block. So it works for every future edition without another change.

Verified across every event on the route:

```
aisummit26                 -> CTA present
aisummit25                 -> absent
v1-2024                    -> absent
hacknight-3-linkup-2026    -> absent
hacknight-edreams-2024     -> absent
hacknight-june-2026        -> absent
skillathon-hacknight-2026  -> absent
vibecode-hacknight-2026    -> absent
```

## Also

- Adds `sponsor_contact_click` to the `OutboundEvent` union, so the mailto is measurable alongside the existing `sponsorship_deck_click`.
- The deck click carries `source: 'sponsor-block'`, distinguishing it from the existing empty-state and events-page CTAs.

## Note

Copy is hardcoded English, matching the other newer org components. If these surfaces are due an i18n pass, this adds three more strings to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)