### PR TITLE
Fix OG metadata icons

### DIFF
--- a/app/components/brand/OpenGraphCard.tsx
+++ b/app/components/brand/OpenGraphCard.tsx
@@ -29,6 +29,21 @@ function PixelCorners({ color }: { color: string }) {
   )
 }
 
+function PixelMarker({ color }: { color: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flex: '0 0 auto',
+        width: 9,
+        height: 9,
+        marginRight: 13,
+        backgroundColor: color,
+      }}
+    />
+  )
+}
+
 export function formatOgDate(startDate: string, endDate?: string) {
   const start = new Date(startDate)
   const end = endDate ? new Date(endDate) : start
@@ -131,15 +146,15 @@ export default function OpenGraphCard({
           </div>
 
           {date ? (
-            <div style={{ display: 'flex', marginTop: 34, color: COLORS.ink, fontSize: 24, fontWeight: 700 }}>
-              <span style={{ display: 'flex', marginRight: 12, color: COLORS.pink }}>■</span>
+            <div style={{ display: 'flex', alignItems: 'center', marginTop: 34, color: COLORS.ink, fontSize: 24, fontWeight: 700 }}>
+              <PixelMarker color={COLORS.pink} />
               {date}
             </div>
           ) : null}
 
           {location ? (
-            <div style={{ display: 'flex', marginTop: 11, color: COLORS.dim, fontSize: 23, fontWeight: 600 }}>
-              <span style={{ display: 'flex', marginRight: 12, color: COLORS.cyan }}>■</span>
+            <div style={{ display: 'flex', alignItems: 'center', marginTop: 11, color: COLORS.dim, fontSize: 23, fontWeight: 600 }}>
+              <PixelMarker color={COLORS.cyan} />
               {location}
             </div>
           ) : null}


### PR DESCRIPTION
## Fix

The date and location markers in the OG card were Unicode `■` glyphs. Satori's default font stack does not reliably include that glyph, so social images rendered missing/replacement icons.

This replaces those font glyphs with 9×9 CSS pixel squares using the existing HackBarna pink/cyan colors.

No image/font loading is involved, so the markers are deterministic in Vercel OG rendering.